### PR TITLE
move bundled dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "preversion": "run-s test build"
   },
   "devDependencies": {
+    "@jridgewell/gen-mapping": "^0.3.0",
+    "@jridgewell/trace-mapping": "^0.3.9",
     "@rollup/plugin-node-resolve": "13.2.1",
     "@rollup/plugin-typescript": "8.3.0",
     "@types/mocha": "9.1.1",
@@ -63,9 +65,5 @@
     "prettier": "2.5.1",
     "rollup": "2.66.0",
     "typescript": "4.5.5"
-  },
-  "dependencies": {
-    "@jridgewell/gen-mapping": "^0.3.0",
-    "@jridgewell/trace-mapping": "^0.3.9"
   }
 }


### PR DESCRIPTION
This package install two much deep packages as dependencies while production environment installing, but they are already bundled while building. This PR helps this package be a lite package without changing any runtime behaviour.